### PR TITLE
Included branch and commit message naming conventions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # soffan-decide
 Assignment 1
+
+
+### Branch naming convention
+
+Branch names must follow this structure:  
+**`<type>/decide-<issue-number>`**
+
+- **type**: one of `feat`, `fix`, `docs`, `refactor`, `test`
+- **issue-number**: the GitHub issue ID
+
+Examples:
+- feat/decide-1
+- fix/decide-2
+- docs/decide-3
+
+
+### Commit message convention
+
+Commit messages must follow this structure:  
+**`<type>: <short description>. #<issue-number>`**
+
+- **type**: one of `feat`, `fix`, `docs`, `refactor`, `test`
+- **issue-number**: the GitHub issue ID
+
+Examples:
+- feat: initial Gradle setup. #1
+- fix: resolve login bug on mobile devices. #2


### PR DESCRIPTION
Added a short description for how to name branches and what to use as commit messages in this project. See issue #20.